### PR TITLE
Support list filter values via the 'in' operator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "psr-lakehouse"
-version = "0.3.2"
+version = "0.3.3"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/psr/lakehouse/client.py
+++ b/src/psr/lakehouse/client.py
@@ -33,7 +33,19 @@ class Client:
 
         if filters:
             for col, value in filters.items():
-                if value is not None:
+                if value is None:
+                    continue
+                if isinstance(value, (list, tuple, set)):
+                    if not value:
+                        raise LakehouseError(f"Filter for column '{col}' received an empty list.")
+                    query_filters.append(
+                        {
+                            "column": f"{model_name}.{col}",
+                            "value": [str(item) for item in value],
+                            "operator": "in",
+                        }
+                    )
+                else:
                     query_filters.append(
                         {
                             "column": f"{model_name}.{col}",
@@ -158,7 +170,9 @@ class Client:
         Args:
             table_name: Name of the table to query (e.g., "ccee_spot_price")
             data_columns: Optional columns to fetch. If not provided, all columns will be fetched.
-            filters: Optional dict of column: value filters (equality)
+            filters: Optional dict of column: value filters. A scalar value filters by
+                equality; a list of values filters with an SQL IN clause
+                (e.g., {"subsystem": ["NORTH", "SOUTH"]})
             start_reference_date: Optional start date filter (inclusive)
             end_reference_date: Optional end date filter (exclusive)
             group_by: Optional list of columns to group by

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -100,6 +100,56 @@ class TestFetchDataframe:
         assert df["CCEESpotPrice.subsystem"].iloc[0] == "SOUTHEAST"
 
     @responses.activate
+    def test_fetch_dataframe_with_list_filter_uses_in_operator(self):
+        """Test that a list filter value is sent as an 'in' filter."""
+
+        mock_data = [
+            {
+                "CCEESpotPrice.reference_date": "2023-05-01T00:00:00-03:00",
+                "CCEESpotPrice.subsystem": "NORTH",
+                "CCEESpotPrice.spot_price": 65.0,
+            },
+            {
+                "CCEESpotPrice.reference_date": "2023-05-01T00:00:00-03:00",
+                "CCEESpotPrice.subsystem": "SOUTH",
+                "CCEESpotPrice.spot_price": 70.0,
+            },
+        ]
+
+        responses.add(
+            responses.POST,
+            "https://test-api.example.com/query/",
+            json=make_query_response(mock_data),
+            status=200,
+        )
+
+        df = psr.lakehouse.client.fetch_dataframe(
+            table_name="ccee_spot_price",
+            data_columns=["reference_date", "subsystem", "spot_price"],
+            filters={"subsystem": ["NORTH", "SOUTH"]},
+        )
+
+        assert len(df) == 2
+
+        import json
+
+        request_body = json.loads(responses.calls[0].request.body)
+        subsystem_filters = [f for f in request_body["query_filters"] if f["column"] == "CCEESpotPrice.subsystem"]
+        assert subsystem_filters == [
+            {"column": "CCEESpotPrice.subsystem", "value": ["NORTH", "SOUTH"], "operator": "in"}
+        ]
+
+    def test_fetch_dataframe_with_empty_list_filter_raises_error(self):
+        """Test that an empty list filter value raises an error."""
+
+        with pytest.raises(LakehouseError, match="empty list"):
+            psr.lakehouse.client.fetch_dataframe(
+                table_name="ccee_spot_price",
+                data_columns=["reference_date", "subsystem", "spot_price"],
+                filters={"subsystem": []},
+            )
+
+    @responses.activate
     def test_fetch_dataframe_empty_result(self):
         """Test handling of empty results."""
 


### PR DESCRIPTION
## Summary

Passing a list as a filter value previously stringified the whole list into a single `=` comparison:

```python
client.fetch_dataframe(
    table_name="ons_power_plant_hourly_generation",
    ...,
    filters={"operation_mode": ["TYPE_MMGD", "TYPE_III"]},
)
```

sent `{"value": "['TYPE_MMGD', 'TYPE_III']", "operator": "="}`, which the server rejected with:

```
HTTP 422 Unprocessable Entity: Could not parse '['TYPE_MMGD', 'TYPE_III']' into type 'VARCHAR(9)'
```

The server API now supports `in`/`not in` operators with `value: str | list[str]`, so the client builds an `in` filter when the value is a list/tuple/set:

```json
{"column": "ONSPowerPlantHourlyGeneration.operation_mode", "value": ["TYPE_MMGD", "TYPE_III"], "operator": "in"}
```

## Changes

- `_build_query_filters`: list/tuple/set values → `in` operator with stringified items; scalars keep the existing `=` behavior
- Empty list filters raise a clear `LakehouseError` instead of producing an invalid query
- Updated `fetch_dataframe` docstring for the `filters` param
- Added unit tests for the `in` request body and the empty-list error

## Test plan

- [x] `make lint`
- [x] `make test` — 51 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)