### PR TITLE
Update for performance improvements from the server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "psr-lakehouse"
-version = "0.3.3"
+version = "0.4.0"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/psr/lakehouse/client.py
+++ b/src/psr/lakehouse/client.py
@@ -1,5 +1,4 @@
 import re
-import warnings
 from datetime import datetime, timedelta
 
 import pandas as pd
@@ -119,34 +118,39 @@ class Client:
 
         return joins
 
-    def _fetch_all_pages(self, json_body: dict, page_size: int = 1000, timeout: int = 600) -> list[dict]:
-        """Fetch all pages of results."""
-        all_data = []
+    def _fetch_all_pages(
+        self, json_body: dict, page_size: int = 10000, timeout: int = 600
+    ) -> tuple[list[str] | None, list]:
+        """Fetch all pages of results.
+
+        Requests the columnar response format and returns (columns, rows). When the
+        server predates the columnar format and returns records, columns is None and
+        rows is the list of record dicts.
+        """
+        columns = None
+        all_rows = []
         page = 1
 
         while True:
-            try:
-                response = connector.post(
-                    "/query/",
-                    json_body,
-                    params={"page": page, "page_size": page_size},
-                    timeout=timeout,
-                )
-            except LakehouseError:
-                if all_data:
-                    warnings.warn(
-                        f"Request failed on page {page}. Returning partial data ({page - 1} page(s) fetched).",
-                        stacklevel=2,
-                    )
-                    break
-                raise
-            all_data.extend(response["data"])
+            response = connector.post(
+                "/query/",
+                json_body,
+                params={"page": page, "page_size": page_size, "response_format": "columnar"},
+                timeout=timeout,
+            )
+            data = response["data"]
+            if isinstance(data, list):
+                all_rows.extend(data)
+            else:
+                if columns is None:
+                    columns = data["columns"]
+                all_rows.extend(data["rows"])
 
             if not response["pagination"]["has_next"]:
                 break
             page += 1
 
-        return all_data
+        return columns, all_rows
 
     def fetch_dataframe(
         self,
@@ -160,8 +164,9 @@ class Client:
         order_by: list[dict] | None = None,
         aggregation_method: str | None = None,
         joins: list[dict] | None = None,
+        latest_only: bool = True,
         output_timezone: str = "America/Sao_Paulo",
-        page_size: int = 1000,
+        page_size: int = 10000,
         timeout: int = 600,
     ) -> pd.DataFrame:
         """
@@ -180,8 +185,14 @@ class Client:
             order_by: Optional list of dicts with "column" and "direction" keys for ordering results (e.g., [{"column": "reference_date", "direction": "desc"}])
             aggregation_method: Aggregation method (sum, avg, min, max) - required if group_by is set
             joins: Optional list of dicts with "table", "on", and "type" keys for joining other tables
+            latest_only: If True (default), each table is deduplicated server-side to the latest
+                non-deleted version of each datapoint. Set to False to return the full version
+                history, including superseded and soft-deleted rows. Note: for tables whose
+                versioning constraint spans all data fields (ONS registry-source and
+                versioned-metadata tables), dedup is currently a no-op and duplicates may still
+                be returned (lakehouse_server issue #427).
             output_timezone: Timezone for datetime output (default: "America/Sao_Paulo")
-            page_size: Number of records per page for API pagination (default: 1000)
+            page_size: Number of records per page for API pagination (default: 10000)
             timeout: Timeout in seconds for API requests (default: 600)
 
         Returns:
@@ -212,6 +223,7 @@ class Client:
         # Build JSON request body
         json_body = {
             "query_data": self._build_query_data(model_name, all_columns),
+            "latest_only": latest_only,
             "output_timezone": output_timezone,
         }
 
@@ -235,25 +247,25 @@ class Client:
         return self.fetch_dataframe_from_query(json_body, page_size=page_size, timeout=timeout)
 
     def fetch_dataframe_from_query(
-        self, json_body: dict, page_size: int = 1000, timeout: int | None = 600
+        self, json_body: dict, page_size: int = 10000, timeout: int | None = 600
     ) -> pd.DataFrame:
         """
         Fetch data from the API using a custom query JSON body and return as a pandas DataFrame.
 
         Args:
             json_body: JSON request body for the query
-            page_size: Number of records per page for API pagination (default: 1000)
+            page_size: Number of records per page for API pagination (default: 10000)
             timeout: Timeout in seconds for API requests (default: 600)
 
         Returns:
             pandas DataFrame with the query results
         """
-        data = self._fetch_all_pages(json_body, page_size=page_size, timeout=timeout)
-        df = pd.DataFrame(data)
+        columns, rows = self._fetch_all_pages(json_body, page_size=page_size, timeout=timeout)
+        df = pd.DataFrame(rows, columns=columns) if columns is not None else pd.DataFrame(rows)
 
         date_cols = [col for col in df.columns if col.endswith("reference_date")]
         if date_cols:
-            df[date_cols] = df[date_cols].apply(pd.to_datetime)
+            df[date_cols] = df[date_cols].apply(pd.to_datetime, format="ISO8601")
 
         return df
 

--- a/src/psr/lakehouse/connector.py
+++ b/src/psr/lakehouse/connector.py
@@ -1,6 +1,8 @@
 import os
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from psr.lakehouse.exceptions import LakehouseError
 
@@ -10,11 +12,28 @@ class Connector:
 
     _is_initialized: bool = False
     _base_url: str
+    _session: requests.Session
 
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
+
+    @staticmethod
+    def _create_session() -> requests.Session:
+        """Create a session with keep-alive and retries on transient server errors."""
+        session = requests.Session()
+        adapter = HTTPAdapter(
+            max_retries=Retry(
+                total=3,
+                backoff_factor=1,
+                status_forcelist=[502, 503, 504],
+                allowed_methods=["GET", "POST"],
+            )
+        )
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        return session
 
     def initialize(
         self,
@@ -34,8 +53,10 @@ class Connector:
             )
         self._base_url = self._base_url.rstrip("/")
 
+        self._session = self._create_session()
+
         try:
-            response = requests.get(f"{self._base_url}/health-check", timeout=10)
+            response = self._session.get(f"{self._base_url}/health-check", timeout=10)
             if not response.json():
                 raise LakehouseError("Health check failed: API returned a non-truthy response.")
         except requests.exceptions.RequestException as e:
@@ -65,7 +86,7 @@ class Connector:
         url = f"{self._base_url}{endpoint}"
 
         try:
-            response = requests.post(
+            response = self._session.post(
                 url,
                 json=json_body,
                 params=params,
@@ -98,7 +119,7 @@ class Connector:
         url = f"{self._base_url}{endpoint}"
 
         try:
-            response = requests.get(
+            response = self._session.get(
                 url,
                 params=params,
                 timeout=60,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,6 +14,7 @@ def setup_unit_test():
 
     connector._is_initialized = True
     connector._base_url = "https://test-api.example.com"
+    connector._session = connector._create_session()
 
     yield
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,5 +1,3 @@
-import warnings
-
 import pandas as pd
 import pytest
 import responses
@@ -8,30 +6,34 @@ import psr.lakehouse
 from psr.lakehouse.exceptions import LakehouseError
 
 
-def make_query_response(data: list, page: int = 1, page_size: int = 1000, total_count: int | None = None):
-    """Helper to create a standard query API response."""
-    if total_count is None:
-        total_count = len(data)
-    total_pages = (total_count + page_size - 1) // page_size if total_count > 0 else 0
+def make_query_response(data: list, page: int = 1, page_size: int = 1000, has_next: bool = False):
+    """Helper to create a standard query API response in the columnar format."""
+    columns = list(data[0].keys()) if data else []
+    rows = [[record[col] for col in columns] for record in data]
 
     return {
-        "data": data,
+        "data": {"columns": columns, "rows": rows},
         "pagination": {
             "page": page,
             "page_size": page_size,
-            "total_count": total_count,
-            "total_pages": total_pages,
-            "has_next": page < total_pages,
+            "has_next": has_next,
             "has_prev": page > 1,
         },
         "query_info": {
             "sql": "SELECT ...",
-            "columns_selected": len(data[0]) if data else 0,
+            "columns_selected": len(columns),
             "has_filters": True,
             "has_joins": False,
             "has_group_by": False,
         },
     }
+
+
+def make_records_response(data: list, page: int = 1, page_size: int = 1000, has_next: bool = False):
+    """Helper to create a query API response in the legacy records format."""
+    response = make_query_response(data, page=page, page_size=page_size, has_next=has_next)
+    response["data"] = data
+    return response
 
 
 class TestFetchDataframe:
@@ -139,6 +141,47 @@ class TestFetchDataframe:
             {"column": "CCEESpotPrice.subsystem", "value": ["NORTH", "SOUTH"], "operator": "in"}
         ]
 
+    @responses.activate
+    def test_fetch_dataframe_latest_only_forwarded(self):
+        """Test that latest_only defaults to True and is forwarded in the request body."""
+
+        mock_data = [
+            {
+                "CCEESpotPrice.reference_date": "2023-05-01T00:00:00-03:00",
+                "CCEESpotPrice.spot_price": 69.04,
+            },
+        ]
+
+        responses.add(
+            responses.POST,
+            "https://test-api.example.com/query/",
+            json=make_query_response(mock_data),
+            status=200,
+        )
+        responses.add(
+            responses.POST,
+            "https://test-api.example.com/query/",
+            json=make_query_response(mock_data),
+            status=200,
+        )
+
+        import json
+
+        psr.lakehouse.client.fetch_dataframe(
+            table_name="ccee_spot_price",
+            data_columns=["reference_date", "spot_price"],
+        )
+        request_body = json.loads(responses.calls[0].request.body)
+        assert request_body["latest_only"] is True
+
+        psr.lakehouse.client.fetch_dataframe(
+            table_name="ccee_spot_price",
+            data_columns=["reference_date", "spot_price"],
+            latest_only=False,
+        )
+        request_body = json.loads(responses.calls[1].request.body)
+        assert request_body["latest_only"] is False
+
     def test_fetch_dataframe_with_empty_list_filter_raises_error(self):
         """Test that an empty list filter value raises an error."""
 
@@ -193,48 +236,14 @@ class TestFetchDataframe:
         responses.add(
             responses.POST,
             "https://test-api.example.com/query/",
-            json={
-                "data": page1_data,
-                "pagination": {
-                    "page": 1,
-                    "page_size": 1,
-                    "total_count": 2,
-                    "total_pages": 2,
-                    "has_next": True,
-                    "has_prev": False,
-                },
-                "query_info": {
-                    "sql": "SELECT ...",
-                    "columns_selected": 3,
-                    "has_filters": False,
-                    "has_joins": False,
-                    "has_group_by": False,
-                },
-            },
+            json=make_query_response(page1_data, page=1, page_size=1, has_next=True),
             status=200,
         )
 
         responses.add(
             responses.POST,
             "https://test-api.example.com/query/",
-            json={
-                "data": page2_data,
-                "pagination": {
-                    "page": 2,
-                    "page_size": 1,
-                    "total_count": 2,
-                    "total_pages": 2,
-                    "has_next": False,
-                    "has_prev": True,
-                },
-                "query_info": {
-                    "sql": "SELECT ...",
-                    "columns_selected": 3,
-                    "has_filters": False,
-                    "has_joins": False,
-                    "has_group_by": False,
-                },
-            },
+            json=make_query_response(page2_data, page=2, page_size=1),
             status=200,
         )
 
@@ -275,6 +284,40 @@ class TestFetchDataframe:
         request_url = responses.calls[0].request.url
         assert "page_size=500" in request_url
         assert "page=1" in request_url
+        assert "response_format=columnar" in request_url
+
+    @responses.activate
+    def test_fetch_dataframe_records_format_fallback(self):
+        """Test that a records-shaped response (server predating columnar) is still handled."""
+
+        mock_data = [
+            {
+                "CCEESpotPrice.reference_date": "2023-05-01T00:00:00-03:00",
+                "CCEESpotPrice.subsystem": "NORTH",
+                "CCEESpotPrice.spot_price": 69.04,
+            },
+            {
+                "CCEESpotPrice.reference_date": "2023-05-01T00:00:00-03:00",
+                "CCEESpotPrice.subsystem": "SOUTH",
+                "CCEESpotPrice.spot_price": 70.00,
+            },
+        ]
+
+        responses.add(
+            responses.POST,
+            "https://test-api.example.com/query/",
+            json=make_records_response(mock_data),
+            status=200,
+        )
+
+        df = psr.lakehouse.client.fetch_dataframe(
+            table_name="ccee_spot_price",
+            data_columns=["reference_date", "subsystem", "spot_price"],
+        )
+
+        assert len(df) == 2
+        assert "CCEESpotPrice.spot_price" in df.columns
+        assert df["CCEESpotPrice.subsystem"].tolist() == ["NORTH", "SOUTH"]
 
     def test_fetch_dataframe_timeout_forwarded(self):
         """Test that custom timeout is forwarded to connector.post()."""
@@ -932,31 +975,17 @@ class TestFetchDataframe:
         )
 
 
-class TestFetchPartialDataOnTimeout:
-    def test_timeout_on_page_2_returns_partial_data_with_warning(self):
-        """Test that a timeout on page 2 returns data from page 1 with a warning."""
+class TestFetchFailureMidPagination:
+    def test_failure_on_page_2_raises_error(self):
+        """Test that a failure on page 2 raises instead of returning partial data."""
         from unittest.mock import patch
 
-        page1_response = {
-            "data": [
-                {"reference_date": "2023-05-01T00:00:00-03:00", "subsystem": "NORTH", "value": 1},
-            ],
-            "pagination": {
-                "page": 1,
-                "page_size": 1,
-                "total_count": 3,
-                "total_pages": 3,
-                "has_next": True,
-                "has_prev": False,
-            },
-            "query_info": {
-                "sql": "SELECT ...",
-                "columns_selected": 3,
-                "has_filters": False,
-                "has_joins": False,
-                "has_group_by": False,
-            },
-        }
+        page1_response = make_query_response(
+            [{"reference_date": "2023-05-01T00:00:00-03:00", "subsystem": "NORTH", "value": 1}],
+            page=1,
+            page_size=1,
+            has_next=True,
+        )
 
         def mock_post(url, json_body, params=None, timeout=None):
             if params and params.get("page") == 1:
@@ -964,21 +993,14 @@ class TestFetchPartialDataOnTimeout:
             raise LakehouseError("Request timed out")
 
         with patch.object(psr.lakehouse.connector, "post", side_effect=mock_post):
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                df = psr.lakehouse.client.fetch_dataframe(
+            with pytest.raises(LakehouseError, match="Request timed out"):
+                psr.lakehouse.client.fetch_dataframe(
                     table_name="ons_energy_load_daily",
                     data_columns=["value"],
                 )
 
-                assert len(df) == 1
-                assert df.iloc[0]["value"] == 1
-                assert len(w) == 1
-                assert "page 2" in str(w[0].message)
-                assert "1 page(s) fetched" in str(w[0].message)
-
     def test_timeout_on_page_1_raises_error(self):
-        """Test that a timeout on the first page still raises LakehouseError."""
+        """Test that a timeout on the first page raises LakehouseError."""
         from unittest.mock import patch
 
         with patch.object(psr.lakehouse.connector, "post", side_effect=LakehouseError("Request timed out")):

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -77,6 +77,21 @@ class TestConnectorInitialization:
         assert "/health-check" in responses.calls[0].request.url
 
     @responses.activate
+    def test_initialize_creates_session_with_retries(self):
+        """Test that initialization creates a reusable session with retry configuration."""
+        connector = Connector.__new__(Connector)
+        connector._is_initialized = False
+
+        _mock_health_check("https://api.example.com")
+        connector.initialize(base_url="https://api.example.com")
+
+        retries = connector._session.get_adapter("https://api.example.com").max_retries
+        assert retries.total == 3
+        assert retries.backoff_factor == 1
+        assert set(retries.status_forcelist) == {502, 503, 504}
+        assert set(retries.allowed_methods) == {"GET", "POST"}
+
+    @responses.activate
     def test_initialize_health_check_failure_non_truthy(self):
         """Test that initialization fails when health check returns non-truthy response."""
         connector = Connector.__new__(Connector)


### PR DESCRIPTION
Client-side counterpart of the lakehouse_server pr/querying_improvements branch:

- Reuse a single requests.Session with keep-alive and retries (3 retries with backoff on 502/503/504) for all API calls
- Request the columnar response format and build DataFrames directly from columns/rows, with a fallback for servers that still return the records shape
- Raise the default page_size from 1000 to 10000
- Parse reference_date columns with an explicit ISO8601 format
- Raise LakehouseError on mid-pagination failure instead of returning partial data with a warning
- Expose latest_only (default True) on fetch_dataframe and pass it through in the query body
