### PR TITLE
Log in by pasting a one-time code instead of a callback URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,14 +49,15 @@ key to send. Signing in therefore happens **in a browser** — the only flow tha
 account in a pool that also offers Google and passkeys — and `auth.py`'s whole job is getting the
 resulting cookie into the client. It is cached in `~/.psr-lakehouse/session.json` (mode 0600).
 
-- The client must *start* the flow (`_start_flow`), because the ALB only completes a sign-in for
-  whoever holds the `AWSALBAuthNonce` cookie it issues, and that cookie is here rather than in
-  the browser. Consequently the browser ends on a **401** whose URL still carries an unspent
-  authorization code; the user pastes that URL back and `_finish_from_callback` redeems it from
-  here. Letting the browser run the flow end to end would leave the browser holding the session.
-- This relies on the ALB validating the nonce *before* spending the code — undocumented, but
-  confirmed working against production. `_paste_cookie` is the fallback should that order ever
-  change: `AWSELBAuthSessionCookie-0` copied out of the browser's devtools by hand.
+- The hand-over works like pairing a device. `login` opens the browser at the lakehouse's
+  `/auth/cli` page; the browser runs the whole Cognito flow on its own behalf and lands on that
+  page holding a fresh session. The page (served by `lakehouse_server`'s `app/cli_auth/`) banks
+  the session cookies behind a **one-time code** (10 minutes, single use) and shows the code;
+  the user pastes it into the terminal and `_redeem_code` spends it at `POST /auth/cli/token` —
+  reachable without a session, like `/health-check` — for the cookies plus the signed-in email.
+- `_paste_cookie` is the fallback whenever the code cannot be redeemed (an old server, a load
+  balancer missing the redeem endpoint's forwarding rule): `AWSELBAuthSessionCookie-0` copied
+  out of the browser's devtools by hand.
 - `connector._send()` recognises the bounce by comparing the host of the *final* URL against
   `base_url` — `requests` follows the redirect, so the status code alone does not reveal it.
   On a bounce it logs in and retries the request once.
@@ -64,9 +65,8 @@ resulting cookie into the client. It is cached in `~/.psr-lakehouse/session.json
   or not there is a session; the state is only discovered on the first real request.
 - No unattended login is possible (a browser is required); jobs reuse a session logged in
   interactively, via `LAKEHOUSE_SESSION_FILE`. `LAKEHOUSE_AUTO_LOGIN=0` disables the prompt.
-- The client never learns *which* account it holds a session for: the identity lives in the
-  `x-amzn-oidc-data` header the ALB sends to the app, which the app does not echo back. So
-  `whoami` reports validity, not an email.
+- The redeem endpoint answers with the account's email, which is cached alongside the cookies —
+  `whoami` reports who is logged in as well as whether the session is still valid.
 - Server side: `lakehouse_server`'s `app/core/alb_auth.py` additionally requires a **verified**
   email in an allowed domain (`psr-inc.com`), answering `403` otherwise.
 

--- a/src/psr/lakehouse/__main__.py
+++ b/src/psr/lakehouse/__main__.py
@@ -50,7 +50,8 @@ def _whoami(args: argparse.Namespace) -> int:
         return 1
 
     state = "expired" if info["expired"] else f"valid until {_format_timestamp(info['expires_at'])}"
-    print(f"Logged in to {url} ({state})")
+    who = f" as {info['email']}" if info.get("email") else ""
+    print(f"Logged in to {url}{who} ({state})")
     print(f"Session cached in {auth.session_file()}")
     return 1 if info["expired"] else 0
 

--- a/src/psr/lakehouse/auth.py
+++ b/src/psr/lakehouse/auth.py
@@ -12,19 +12,18 @@ callback a CLI could listen on — an `Authorization` header changes nothing, th
 still bounced. So signing in happens in a browser, and this module's job is to get the
 resulting cookie *here*.
 
-That last part is the whole difficulty, and it explains the shape of `login`. The flow must be
-started by this client, not by the browser: `_start_flow` collects the `AWSALBAuthNonce` cookie
-the load balancer issues, and the callback at the end is only honoured for whoever holds it.
-The browser therefore signs the user in and then stops on a `401` at a URL that still carries
-an unspent authorization code, which the user pastes back so `_finish_from_callback` can redeem
-it from here. Were the browser allowed to run the flow end to end instead, it would be the
-browser that ended up holding the session — no use to a Python process.
+The hand-over works like pairing a device. `login` opens the browser at the lakehouse's
+`/auth/cli` page, and the browser runs the whole Cognito flow on its own behalf — password,
+Google, a passkey, whatever the account uses — ending up on that page with a fresh session.
+The page banks the session cookies server-side behind a one-time code (ten minutes, single
+use) and shows the code; the user pastes it into the terminal, and `_redeem_code` spends it at
+`POST /auth/cli/token` — reachable without a session, like `/health-check` — for the cookies
+plus the signed-in email. The server side of this lives in `lakehouse_server`'s
+`app/cli_auth/`.
 
-This works because the load balancer validates the nonce *before* it spends the code, which is
-undocumented but confirmed against production: the browser's rejected callback leaves the code
-untouched for us. `_paste_cookie` stays as the fallback should that order ever change — the
-cookie is then copied out of the browser by hand, which is clumsier but cannot be defeated by
-any of this.
+`_paste_cookie` is the fallback when the code cannot be redeemed (an old server, a load
+balancer missing the redeem endpoint's forwarding rule): the cookie is then copied out of the
+browser's devtools by hand, which is clumsier but depends on nothing.
 
 The session is cached in `~/.psr-lakehouse/session.json`, so this is a weekly event rather than
 a per-script one.
@@ -47,6 +46,11 @@ from psr.lakehouse.exceptions import LakehouseAuthError
 # Cheap, always-present, and *protected* — unlike `/health-check`, which has its own ALB rule
 # that forwards without authentication and so never reveals whether we are logged in.
 _PROBE_PATH = "/openapi.json"
+
+# The two halves of the code hand-over: the page the browser signs in to (which shows the
+# code), and the endpoint the code is redeemed at (reachable without a session).
+_LOGIN_PATH = "/auth/cli"
+_TOKEN_PATH = "/auth/cli/token"
 
 # The load balancer splits its session cookie across `-0`, `-1`, ... when the claims are large,
 # so this is a prefix rather than a name.
@@ -118,8 +122,12 @@ def _store_key(base_url: str) -> str:
     return base_url.rstrip("/")
 
 
-def save_session(base_url: str, session: requests.Session) -> None:
-    """Persist the load-balancer cookies held by `session` for `base_url`."""
+def save_session(base_url: str, session: requests.Session, email: str | None = None) -> None:
+    """Persist the load-balancer cookies held by `session` for `base_url`.
+
+    `email` is who the session belongs to, when the login learned it — the cookie itself is
+    opaque, so this is the only place the identity can be kept for `whoami` to answer with.
+    """
     cookies = [
         {
             "name": cookie.name,
@@ -139,7 +147,10 @@ def save_session(base_url: str, session: requests.Session) -> None:
         )
 
     store = _read_store()
-    store["sessions"][_store_key(base_url)] = {"saved_at": int(time.time()), "cookies": cookies}
+    entry = {"saved_at": int(time.time()), "cookies": cookies}
+    if email:
+        entry["email"] = email
+    store["sessions"][_store_key(base_url)] = entry
     _write_store(store)
 
 
@@ -198,8 +209,10 @@ def session_info(base_url: str) -> dict | None:
         return None
 
     expiries = [cookie["expires"] for cookie in _stored_cookies(entry) if cookie.get("expires")]
+    email = entry.get("email") if isinstance(entry, dict) else None
     return {
         "saved_at": entry.get("saved_at") if isinstance(entry, dict) else None,
+        "email": email if isinstance(email, str) else None,
         "expires_at": min(expiries) if expiries else None,
         "expired": bool(expiries) and min(expiries) <= time.time(),
     }
@@ -225,10 +238,6 @@ def _clear_alb_cookies(session: requests.Session) -> None:
         requests.cookies.remove_cookie_by_name(session.cookies, name)
 
 
-def _has_alb_cookie(session: requests.Session) -> bool:
-    return any(cookie.name.startswith(_ALB_COOKIE_PREFIX) for cookie in session.cookies)
-
-
 # --------------------------------------------------------------------------- #
 # Recognising the bounce to the identity provider
 # --------------------------------------------------------------------------- #
@@ -240,10 +249,6 @@ def _host(url: str) -> str:
 def _hostname(url: str) -> str:
     """Host without the port, which is the only form a cookie domain may take."""
     return (urlparse(url).hostname or "").lower()
-
-
-def _origin(url: str) -> tuple[str, str]:
-    return urlparse(url).scheme.lower(), _host(url)
 
 
 def bounced_to_idp(response: requests.Response, base_url: str) -> bool:
@@ -344,45 +349,40 @@ def login(base_url: str, session: requests.Session | None = None) -> None:
     """
     base_url = base_url.rstrip("/")
     session = session if session is not None else requests.Session()
-    authorize_url = _start_flow(session, base_url)
+    _require_behind_login(session, base_url)
 
-    _open_browser(authorize_url)
+    login_url = f"{base_url}{_LOGIN_PATH}"
+    _open_browser(login_url)
 
     # Printed whether or not opening worked: a browser that fails to launch is common enough (a
     # remote shell, WSL without a desktop session) that hiding the URL would strand the user.
     note("")
     note("Sign in in your browser — password, Google, a passkey, whatever the account uses:")
-    note(f"  {authorize_url}")
+    note(f"  {login_url}")
     note("")
-    note(f"It ends on a '401 Authorization Required' page at {_host(base_url)}. That is expected")
-    note("and means the sign-in worked: the load balancer will only spend it for whoever started")
-    note("the flow, which is this client. Copy that page's URL out of the address bar.")
+    note("It ends on a page showing a one-time code. Paste that code here.")
     note("")
 
-    pasted = _ask("URL from the address bar")
+    code = _ask("Code")
     hint = "The login did not take."
+    email = None
     try:
-        _finish_from_callback(session, base_url, pasted)
+        email = _redeem_code(session, base_url, code)
     except LakehouseAuthError as exc:
         note("")
-        note(f"That callback did not complete the login: {exc.message}")
+        note(f"That code did not complete the login: {exc.message}")
         _paste_cookie(session, base_url)
         hint = f"Check that you copied the value of {_ALB_COOKIE_PREFIX}-0 in full."
 
     _verify(session, base_url, hint)
-    save_session(base_url, session)
-    note(f"Logged in to {base_url}.")
+    save_session(base_url, session, email=email)
+    note(f"Logged in to {base_url}{f' as {email}' if email else ''}.")
 
 
-def _start_flow(session: requests.Session, base_url: str) -> str:
-    """Ask the lakehouse for a login and return the authorize URL it points us at.
-
-    This is the step that makes the rest possible: the load balancer answers with a `302` *and*
-    an `AWSALBAuthNonce` cookie, which lands in `session`. That nonce is what binds the flow to
-    this client, and why the browser cannot be left to complete the flow on its own behalf.
-    """
-    # A stale cookie would make the probe look authenticated and skip the whole flow, which is
-    # the opposite of what an explicit login should do.
+def _require_behind_login(session: requests.Session, base_url: str) -> None:
+    """Confirm there is a login to perform before sending anyone to a browser."""
+    # A stale cookie would make the probe look authenticated and mask what an explicit login is
+    # for; the redeemed cookies replace it anyway.
     _clear_alb_cookies(session)
 
     try:
@@ -390,46 +390,87 @@ def _start_flow(session: requests.Session, base_url: str) -> str:
     except requests.RequestException as exc:
         raise LakehouseAuthError(f"Could not reach {base_url}: {exc}") from exc
 
-    authorize_url = probe.headers.get("location", "") if probe.is_redirect else ""
-    if not authorize_url or _host(authorize_url) == _host(base_url):
+    location = probe.headers.get("location", "") if probe.is_redirect else ""
+    if not location or _host(location) == _host(base_url):
         raise LakehouseAuthError(
             f"{base_url} answered HTTP {probe.status_code} without redirecting to an identity "
             "provider, so it is not behind the load balancer's Cognito authentication and there "
             "is nothing to log in to."
         )
 
-    # This URL is handed to the operating system's URL handler, which will act on whatever scheme
-    # it is given. It arrives in a `Location` header, so it is only as trustworthy as the host in
-    # `base_url` — check it is an ordinary web address before opening it.
-    if urlparse(authorize_url).scheme.lower() not in ("http", "https"):
+    note(f"Logging in to {base_url} via {_host(location)}")
+
+
+def _redeem_code(session: requests.Session, base_url: str, code: str) -> str | None:
+    """Spend the pasted one-time code for the session the browser banked; return the email.
+
+    Raises `LakehouseAuthError` — with enough said to tell a mistyped code from a deployment
+    that cannot redeem codes at all — whenever no cookie was installed.
+    """
+    try:
+        response = session.post(f"{base_url}{_TOKEN_PATH}", json={"code": code.strip()}, timeout=_TIMEOUT)
+    except requests.RequestException as exc:
+        raise LakehouseAuthError(f"redeeming the code failed: {exc}") from exc
+
+    # The redeem endpoint must be reachable *without* a session (that is the point of it), so a
+    # bounce to the identity provider here means the load balancer lacks the endpoint's
+    # forwarding rule — no code will ever work, and retyping it will not help.
+    if _host(response.url) != _host(base_url):
         raise LakehouseAuthError(
-            f"{base_url} redirected the login to something that is not a web address; refusing to "
-            f"open it: {authorize_url[:80]}"
+            f"the load balancer sent the code to its login page instead of the lakehouse — it is "
+            f"missing the rule that forwards {_TOKEN_PATH} without authentication"
         )
-
-    note(f"Logging in to {base_url} via {_host(authorize_url)}")
-    return authorize_url
-
-
-def _finish_from_callback(session: requests.Session, base_url: str, pasted: str) -> None:
-    """Replay the browser's callback URL from here, where the nonce cookie is."""
-    pasted = pasted.strip()
-    parsed = urlparse(pasted)
-
-    # The full origin, not just the host: matching on the host alone would accept an `http://`
-    # paste and replay the authorization code over cleartext.
-    if _origin(pasted) != _origin(base_url):
-        raise LakehouseAuthError(f"that is not a {urlparse(base_url).scheme}://{_host(base_url)} URL")
-    if "code=" not in (parsed.query or ""):
-        raise LakehouseAuthError("that URL carries no authorization code, so the sign-in did not finish")
+    if response.status_code in (404, 405):
+        raise LakehouseAuthError(
+            f"{base_url} does not offer the code login (HTTP {response.status_code} on {_TOKEN_PATH}); "
+            "the server may predate it"
+        )
+    if response.status_code != 200:
+        raise LakehouseAuthError(_refusal(response))
 
     try:
-        session.get(pasted, timeout=_TIMEOUT)
-    except requests.RequestException as exc:
-        raise LakehouseAuthError(f"replaying the callback failed: {exc}") from exc
+        payload = response.json()
+    except ValueError as exc:
+        raise LakehouseAuthError("the redeem endpoint answered something that is not JSON") from exc
 
-    if not _has_alb_cookie(session):
-        raise LakehouseAuthError("the load balancer refused to exchange the code (it was probably already spent)")
+    cookies = payload.get("cookies") if isinstance(payload, dict) else None
+    installed = 0
+    for cookie in cookies if isinstance(cookies, list) else []:
+        name = cookie.get("name") if isinstance(cookie, dict) else None
+        value = cookie.get("value") if isinstance(cookie, dict) else None
+        if not isinstance(name, str) or not isinstance(value, str) or not name.startswith(_ALB_COOKIE_PREFIX):
+            continue
+        session.cookies.set_cookie(
+            requests.cookies.create_cookie(
+                name=name,
+                value=value,
+                # `hostname`, not `netloc`: a cookie domain carrying a port matches nothing.
+                domain=_hostname(base_url),
+                path="/",
+                # The server reads the cookies out of a request, where their lifetime is not
+                # visible, so the client stamps the ALB default of a week — see the constant.
+                expires=int(time.time() + _ASSUMED_SESSION_SECONDS),
+                secure=True,
+            )
+        )
+        installed += 1
+
+    if not installed:
+        raise LakehouseAuthError("the code was accepted but no session cookies came back")
+
+    email = payload.get("email")
+    return email if isinstance(email, str) and email else None
+
+
+def _refusal(response: requests.Response) -> str:
+    """The server's own words for refusing a code, when it gave any."""
+    try:
+        detail = response.json().get("detail")
+    except (ValueError, AttributeError):
+        detail = None
+    if isinstance(detail, str) and detail:
+        return detail
+    return f"the code was refused (HTTP {response.status_code})"
 
 
 def _paste_cookie(session: requests.Session, base_url: str) -> None:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -13,8 +13,9 @@ BASE_URL = "https://test-api.example.com"
 IDP = "https://accounts.example.com"
 AUTHORIZE_URL = f"{IDP}/oauth2/authorize?client_id=abc&redirect_uri={BASE_URL}/oauth2/idpresponse&state=xyz"
 
-# What the browser is left showing: a 401 whose URL still carries the unspent code.
-CALLBACK_URL = f"{BASE_URL}/oauth2/idpresponse?code=auth-code&state=xyz"
+# What the browser's code page shows, and what the user pastes back.
+CODE = "one-time-pairing-code"
+EMAIL = "user@psr-inc.com"
 
 
 @pytest.fixture(autouse=True)
@@ -38,82 +39,72 @@ def bounce(mock_api, path=f"{BASE_URL}/openapi.json"):
     mock_api.add(mock_api.GET, path, status=302, headers={"Location": AUTHORIZE_URL})
 
 
-def callback_succeeds(mock_api, expires=None):
-    """The replayed callback: the load balancer spends the code and hands over its cookie."""
-    cookie = "AWSELBAuthSessionCookie-0=session-value; Path=/"
-    if expires:
-        cookie += f"; Expires={time.strftime('%a, %d-%b-%Y %H:%M:%S GMT', time.gmtime(expires))}"
-    mock_api.add(
-        mock_api.GET,
-        f"{BASE_URL}/oauth2/idpresponse",
-        status=200,
-        json={"openapi": "3.1.0"},
-        headers={"Set-Cookie": cookie},
-    )
+def redeem_succeeds(mock_api, cookies=None, email=EMAIL):
+    """The redeem endpoint spending the code for the cookies the browser banked."""
+    if cookies is None:
+        cookies = [{"name": "AWSELBAuthSessionCookie-0", "value": "session-value"}]
+    mock_api.add(mock_api.POST, f"{BASE_URL}/auth/cli/token", status=200, json={"cookies": cookies, "email": email})
+
+
+def redeem_refused(mock_api, base=BASE_URL):
+    mock_api.add(mock_api.POST, f"{base}/auth/cli/token", status=400, json={"detail": "That code is invalid."})
 
 
 def authenticated(mock_api, path=f"{BASE_URL}/openapi.json"):
     mock_api.add(mock_api.GET, path, status=200, json={"openapi": "3.1.0"})
 
 
-def log_in(mock_api, monkeypatch, expires=None):
+def log_in(mock_api, monkeypatch):
     """Complete a login, so a test can start from a cached session."""
     bounce(mock_api)
-    callback_succeeds(mock_api, expires=expires)
+    redeem_succeeds(mock_api)
     authenticated(mock_api)
-    monkeypatch.setattr(auth, "_ask", lambda label: CALLBACK_URL)
+    monkeypatch.setattr(auth, "_ask", lambda label: CODE)
     auth.login(BASE_URL)
 
 
 class TestLogin:
-    def test_replays_the_pasted_callback_to_collect_the_cookie(self, mock_api, monkeypatch, dont_open_a_browser):
-        log_in(mock_api, monkeypatch, expires=time.time() + 7 * 24 * 3600)
+    def test_the_pasted_code_redeems_for_the_session(self, mock_api, monkeypatch, dont_open_a_browser):
+        log_in(mock_api, monkeypatch)
 
-        assert dont_open_a_browser == [AUTHORIZE_URL]
+        # The browser runs the whole flow itself, so it is sent to the lakehouse's own login
+        # page — not to an authorize URL only this process could complete.
+        assert dont_open_a_browser == [f"{BASE_URL}/auth/cli"]
+        redeemed = next(call.request for call in mock_api.calls if call.request.url.endswith("/auth/cli/token"))
+        assert json.loads(redeemed.body) == {"code": CODE}
         assert auth.session_info(BASE_URL)["expired"] is False
 
-    def test_the_client_starts_the_flow_so_it_holds_the_nonce(self, mock_api, monkeypatch):
-        # The authorize URL handed to the browser must be the one *this* session was given, or
-        # the load balancer will not honour the callback it comes back with.
-        mock_api.add(
-            mock_api.GET,
-            f"{BASE_URL}/openapi.json",
-            status=302,
-            headers={"Location": AUTHORIZE_URL, "Set-Cookie": "AWSALBAuthNonce=nonce-value; Path=/"},
-        )
-        callback_succeeds(mock_api)
+    def test_the_login_learns_who_it_was_for(self, mock_api, monkeypatch):
+        log_in(mock_api, monkeypatch)
+
+        assert auth.session_info(BASE_URL)["email"] == EMAIL
+
+    def test_a_missing_email_is_not_a_problem(self, mock_api, monkeypatch):
+        bounce(mock_api)
+        redeem_succeeds(mock_api, email=None)
         authenticated(mock_api)
-        monkeypatch.setattr(auth, "_ask", lambda label: CALLBACK_URL)
+        monkeypatch.setattr(auth, "_ask", lambda label: CODE)
 
         auth.login(BASE_URL)
 
-        replayed = next(call.request for call in mock_api.calls if "idpresponse" in call.request.url)
-        assert "AWSALBAuthNonce=nonce-value" in replayed.headers["Cookie"]
+        assert auth.session_info(BASE_URL)["email"] is None
 
-    def test_rejects_a_callback_url_from_another_host(self, mock_api, monkeypatch):
+    def test_whitespace_around_the_pasted_code_is_forgiven(self, mock_api, monkeypatch):
         bounce(mock_api)
-        monkeypatch.setattr(auth, "_ask", lambda label: "https://evil.example.com/?code=stolen")
-        monkeypatch.setattr(auth, "_ask_secret", lambda label: (_ for _ in ()).throw(AssertionError("fell back")))
-
-        with pytest.raises(AssertionError, match="fell back"):
-            auth.login(BASE_URL)
-
-        assert not [call for call in mock_api.calls if "evil.example.com" in call.request.url]
-
-    def test_rejects_a_url_carrying_no_code(self, mock_api, monkeypatch):
-        bounce(mock_api)
-        monkeypatch.setattr(auth, "_ask", lambda label: f"{BASE_URL}/openapi.json")
-        monkeypatch.setattr(auth, "_ask_secret", lambda label: (_ for _ in ()).throw(AssertionError("fell back")))
-
-        with pytest.raises(AssertionError, match="fell back"):
-            auth.login(BASE_URL)
-
-    def test_falls_back_to_the_cookie_when_the_code_was_already_spent(self, mock_api, monkeypatch):
-        bounce(mock_api)
-        # The load balancer spent the code for the browser, so the replay sets no cookie.
-        mock_api.add(mock_api.GET, f"{BASE_URL}/oauth2/idpresponse", status=401, body="401")
+        redeem_succeeds(mock_api)
         authenticated(mock_api)
-        monkeypatch.setattr(auth, "_ask", lambda label: CALLBACK_URL)
+        monkeypatch.setattr(auth, "_ask", lambda label: f"  {CODE}\n")
+
+        auth.login(BASE_URL)
+
+        redeemed = next(call.request for call in mock_api.calls if call.request.url.endswith("/auth/cli/token"))
+        assert json.loads(redeemed.body) == {"code": CODE}
+
+    def test_falls_back_to_the_cookie_when_the_code_is_refused(self, mock_api, monkeypatch):
+        bounce(mock_api)
+        redeem_refused(mock_api)
+        authenticated(mock_api)
+        monkeypatch.setattr(auth, "_ask", lambda label: "expired-code")
         monkeypatch.setattr(auth, "_ask_secret", lambda label: "pasted-cookie-value")
 
         auth.login(BASE_URL)
@@ -122,11 +113,74 @@ class TestLogin:
         auth.load_session(BASE_URL, session)
         assert session.cookies.get("AWSELBAuthSessionCookie-0") == "pasted-cookie-value"
 
+    def test_a_server_without_the_endpoint_is_told_apart_from_a_bad_code(self, mock_api, monkeypatch):
+        bounce(mock_api)
+        mock_api.add(mock_api.POST, f"{BASE_URL}/auth/cli/token", status=404, json={"detail": "Not Found"})
+        authenticated(mock_api)
+        monkeypatch.setattr(auth, "_ask", lambda label: CODE)
+        monkeypatch.setattr(auth, "_ask_secret", lambda label: "pasted-cookie-value")
+        messages = []
+        monkeypatch.setattr(auth, "note", messages.append)
+
+        auth.login(BASE_URL)
+
+        assert any("does not offer the code login" in message for message in messages)
+
+    def test_a_redeem_bounced_to_the_login_page_is_reported_as_misconfiguration(self, mock_api, monkeypatch):
+        # If the ALB lacks the forwarding rule for the redeem endpoint, the POST lands on the
+        # identity provider as HTML — no code will ever work, and the message must say so.
+        bounce(mock_api)
+        mock_api.add(mock_api.POST, f"{BASE_URL}/auth/cli/token", status=302, headers={"Location": AUTHORIZE_URL})
+        mock_api.add(mock_api.GET, AUTHORIZE_URL, status=200, body="<html>sign in</html>")
+        authenticated(mock_api)
+        monkeypatch.setattr(auth, "_ask", lambda label: CODE)
+        messages = []
+        monkeypatch.setattr(auth, "note", messages.append)
+        monkeypatch.setattr(auth, "_ask_secret", lambda label: "pasted-cookie-value")
+
+        auth.login(BASE_URL)
+
+        assert any("missing the rule" in message for message in messages)
+
+    def test_an_answer_with_no_cookies_falls_back(self, mock_api, monkeypatch):
+        bounce(mock_api)
+        redeem_succeeds(mock_api, cookies=[])
+        authenticated(mock_api)
+        monkeypatch.setattr(auth, "_ask", lambda label: CODE)
+        monkeypatch.setattr(auth, "_ask_secret", lambda label: "pasted-cookie-value")
+
+        auth.login(BASE_URL)
+
+        session = requests.Session()
+        auth.load_session(BASE_URL, session)
+        assert session.cookies.get("AWSELBAuthSessionCookie-0") == "pasted-cookie-value"
+
+    def test_only_load_balancer_cookies_are_installed(self, mock_api, monkeypatch):
+        # The response is JSON from the network; only the cookies this flow exists to carry
+        # may enter the jar.
+        bounce(mock_api)
+        redeem_succeeds(
+            mock_api,
+            cookies=[
+                {"name": "AWSELBAuthSessionCookie-0", "value": "session-value"},
+                {"name": "sneaky", "value": "tracking"},
+                "not-a-dict",
+            ],
+        )
+        authenticated(mock_api)
+        monkeypatch.setattr(auth, "_ask", lambda label: CODE)
+
+        session = requests.Session()
+        auth.login(BASE_URL, session=session)
+
+        assert session.cookies.get("AWSELBAuthSessionCookie-0") == "session-value"
+        assert session.cookies.get("sneaky") is None
+
     def test_a_pasted_cookie_that_is_not_accepted_is_reported(self, mock_api, monkeypatch):
         bounce(mock_api)
-        mock_api.add(mock_api.GET, f"{BASE_URL}/oauth2/idpresponse", status=401, body="401")
-        bounce(mock_api)
-        monkeypatch.setattr(auth, "_ask", lambda label: CALLBACK_URL)
+        redeem_refused(mock_api)
+        bounce(mock_api)  # the verification probe is still redirected
+        monkeypatch.setattr(auth, "_ask", lambda label: "wrong-code")
         monkeypatch.setattr(auth, "_ask_secret", lambda label: "truncated")
 
         with pytest.raises(LakehouseAuthError, match="was not accepted"):
@@ -136,9 +190,9 @@ class TestLogin:
 
     def test_nothing_is_cached_when_the_login_does_not_take(self, mock_api, monkeypatch):
         bounce(mock_api)
-        callback_succeeds(mock_api)
+        redeem_succeeds(mock_api)
         bounce(mock_api)  # the verification probe is still redirected
-        monkeypatch.setattr(auth, "_ask", lambda label: CALLBACK_URL)
+        monkeypatch.setattr(auth, "_ask", lambda label: CODE)
 
         with pytest.raises(LakehouseAuthError, match="was not accepted"):
             auth.login(BASE_URL)
@@ -165,68 +219,46 @@ class TestLoginRejections:
             )
         )
         bounce(mock_api)
-        callback_succeeds(mock_api)
+        redeem_succeeds(mock_api)
         authenticated(mock_api)
-        monkeypatch.setattr(auth, "_ask", lambda label: CALLBACK_URL)
+        monkeypatch.setattr(auth, "_ask", lambda label: CODE)
 
         auth.login(BASE_URL, session=session)
 
         assert session.cookies.get("AWSELBAuthSessionCookie-0") == "session-value"
 
-    def test_refuses_to_open_a_redirect_that_is_not_a_web_address(self, mock_api, dont_open_a_browser):
-        # Handed straight to the OS URL handler, so a `Location` naming another scheme is not
-        # something to launch. It arrives from the network, not from the user.
-        mock_api.add(
-            mock_api.GET,
-            f"{BASE_URL}/openapi.json",
-            status=302,
-            headers={"Location": "javascript:alert(1)"},
-        )
-
-        with pytest.raises(LakehouseAuthError, match="not a web address"):
-            auth.login(BASE_URL)
-
-        assert dont_open_a_browser == []
-
-    def test_rejects_a_callback_url_that_downgrades_to_http(self, mock_api, monkeypatch):
-        # Same host, but cleartext: replaying it would put the authorization code on the wire.
-        bounce(mock_api)
-        monkeypatch.setattr(auth, "_ask", lambda label: CALLBACK_URL.replace("https://", "http://"))
-        monkeypatch.setattr(auth, "_ask_secret", lambda label: (_ for _ in ()).throw(AssertionError("fell back")))
-
-        with pytest.raises(AssertionError, match="fell back"):
-            auth.login(BASE_URL)
-
-        assert not [call for call in mock_api.calls if call.request.url.startswith("http://")]
-
     def test_a_session_the_server_refuses_is_not_a_successful_login(self, mock_api, monkeypatch):
         # Past the load balancer, refused by the application: not something to cache and call done.
         bounce(mock_api)
-        callback_succeeds(mock_api)
+        redeem_succeeds(mock_api)
         mock_api.add(mock_api.GET, f"{BASE_URL}/openapi.json", status=403, json={"detail": "Forbidden"})
-        monkeypatch.setattr(auth, "_ask", lambda label: CALLBACK_URL)
+        monkeypatch.setattr(auth, "_ask", lambda label: CODE)
 
         with pytest.raises(LakehouseAuthError, match="refused the account"):
             auth.login(BASE_URL)
 
         assert auth.session_info(BASE_URL) is None
 
-    def test_the_pasted_cookie_is_scoped_without_the_port(self, mock_api, monkeypatch):
+    def test_the_redeemed_cookie_is_scoped_without_the_port(self, mock_api, monkeypatch):
         # A cookie domain may not carry a port; one that does is stored and then never sent.
         based = "https://test-api.example.com:8443"
         mock_api.add(mock_api.GET, f"{based}/openapi.json", status=302, headers={"Location": AUTHORIZE_URL})
-        mock_api.add(mock_api.GET, f"{based}/oauth2/idpresponse", status=401, body="401")
+        mock_api.add(
+            mock_api.POST,
+            f"{based}/auth/cli/token",
+            status=200,
+            json={"cookies": [{"name": "AWSELBAuthSessionCookie-0", "value": "session-value"}], "email": EMAIL},
+        )
         mock_api.add(mock_api.GET, f"{based}/openapi.json", status=200, json={"openapi": "3.1.0"})
-        monkeypatch.setattr(auth, "_ask", lambda label: f"{based}/oauth2/idpresponse?code=c&state=xyz")
-        monkeypatch.setattr(auth, "_ask_secret", lambda label: "hand-copied")
+        monkeypatch.setattr(auth, "_ask", lambda label: CODE)
 
         session = requests.Session()
         auth.login(based, session=session)
 
-        assert session.cookies.get("AWSELBAuthSessionCookie-0") == "hand-copied"
+        assert session.cookies.get("AWSELBAuthSessionCookie-0") == "session-value"
         mock_api.add(mock_api.GET, f"{based}/query/schema", status=200, json={"ok": True})
         session.get(f"{based}/query/schema")
-        assert "AWSELBAuthSessionCookie-0=hand-copied" in mock_api.calls[-1].request.headers["Cookie"]
+        assert "AWSELBAuthSessionCookie-0=session-value" in mock_api.calls[-1].request.headers["Cookie"]
 
 
 class TestSessionFilePermissions:
@@ -278,10 +310,9 @@ class TestStoredSession:
         assert "AWSELBAuthSessionCookie-0=session-value" in mock_api.calls[-1].request.headers["Cookie"]
 
     def test_expired_cookies_are_not_reused(self, mock_api, monkeypatch, session_file):
-        log_in(mock_api, monkeypatch, expires=time.time() + 7 * 24 * 3600)
+        log_in(mock_api, monkeypatch)
 
-        # What a week-old session file looks like. It cannot be produced by logging in:
-        # `requests` drops an already-expired Set-Cookie instead of storing it.
+        # What a week-old session file looks like.
         store = json.loads(session_file.read_text())
         for cookie in store["sessions"][BASE_URL]["cookies"]:
             cookie["expires"] = time.time() - 60
@@ -325,7 +356,12 @@ class TestStoredSession:
         session_file.write_text(json.dumps({"version": 1, "sessions": {BASE_URL: {"cookies": cookies}}}))
 
         assert auth.load_session(BASE_URL, requests.Session()) is False
-        assert auth.session_info(BASE_URL) == {"saved_at": None, "expires_at": None, "expired": False}
+        assert auth.session_info(BASE_URL) == {
+            "saved_at": None,
+            "email": None,
+            "expires_at": None,
+            "expired": False,
+        }
 
     def test_an_unparseable_expiry_does_not_break_the_summary(self, session_file):
         session_file.write_text(
@@ -346,14 +382,14 @@ class TestStoredSession:
 class TestConnectorAuthentication:
     def test_a_bounced_request_logs_in_and_retries(self, mock_api, monkeypatch):
         monkeypatch.setattr(auth, "_interactive", lambda: True)
-        monkeypatch.setattr(auth, "_ask", lambda label: CALLBACK_URL)
+        monkeypatch.setattr(auth, "_ask", lambda label: CODE)
 
         # The first request is bounced to the IdP, then the login flow's own probe is bounced
         # too, and the retry after logging in succeeds.
         bounce(mock_api)
         mock_api.add(mock_api.GET, AUTHORIZE_URL, status=200, body="<html>sign in</html>")
         bounce(mock_api)
-        callback_succeeds(mock_api)
+        redeem_succeeds(mock_api)
         authenticated(mock_api)
 
         assert connector.get("/openapi.json") == {"openapi": "3.1.0"}


### PR DESCRIPTION
## What

Replaces the login flow from #28 with a Claude-style device pairing. The previous flow left the user stranded on a **"401 Authorization Required"** page, asked them to copy a URL out of the address bar, and depended on the ALB validating the client's nonce *before* spending the authorization code — undocumented behavior that could change under us.

Now:

```
$ psr-lakehouse login
Logging in to https://lakehouse.psr-inc.com via <cognito host>

Sign in in your browser — password, Google, a passkey, whatever the account uses:
  https://lakehouse.psr-inc.com/auth/cli

It ends on a page showing a one-time code. Paste that code here.

Code: ****
Logged in to https://lakehouse.psr-inc.com as user@psr-inc.com.
```

The browser runs the whole Cognito flow on its own behalf and lands on the server's `/auth/cli` page, which banks the fresh session cookies behind a one-time code (10 minutes, single use) and shows it. The client redeems the code at `POST /auth/cli/token` for the cookies plus the signed-in email.

Requires the server half: psrenergy/lakehouse_server#451 (deploy that first; see rollout notes below).

## How

- `_start_flow` / `_finish_from_callback` (the nonce trick) are gone; `_require_behind_login` keeps the "is there even a login to do" probe, and `_redeem_code` spends the pasted code.
- The redeem response is network input, so only `AWSELBAuthSessionCookie-*` entries are installed — scoped to the API host without the port, `secure`, stamped with the assumed one-week ALB session lifetime. Everything else in the response is ignored.
- Failure messages distinguish what the user can fix from what they cannot: a refused code carries the server's own words; a 404 says the server predates the endpoint; a bounce to the login page says the load balancer is missing the redeem endpoint's forwarding rule. All of them fall back to the devtools cookie paste (`_paste_cookie`), which depends on nothing.
- The email comes back with the redeemed code and is cached with the session, so **`psr-lakehouse whoami` now says who is logged in**, not just until when. Old `session.json` files without the email keep loading fine.

## Rollout

Release order matters: the server PR (endpoint + ALB forwarding rule for `/auth/cli/token`) must be live before this ships to PyPI. Against an old server the new client fails with a clear message and offers the cookie-paste fallback, so a mismatch is inconvenient rather than broken.

## Testing

`tests/unit/test_auth.py` rewritten for the new flow — 93 tests green, ruff clean. Covers the happy path (code redeemed, email cached, browser pointed at `/auth/cli`), whitespace tolerance, refused/404/bounced/empty-cookie redeems each falling back correctly, cookie filtering and port-stripped scoping, plus all the pre-existing session-store and permission tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSt6PJhJugS8rw65zkkMD2

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSt6PJhJugS8rw65zkkMD2)_